### PR TITLE
feat(ui): implement pit-wall inspired theme and restructure layout

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -4,5 +4,12 @@ headless = true
 [browser]
 gatherUsageStats = false
 
+# Pit-wall inspired dark theme. Fine-grained styling (fonts, table heat colours,
+# status bar) is applied at runtime in src/f1_analysis/app/theme.py.
 [theme]
 base = "dark"
+primaryColor = "#00e5ff"
+backgroundColor = "#0a0a0a"
+secondaryBackgroundColor = "#12151a"
+textColor = "#e8e8e8"
+font = "monospace"

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ src/f1_analysis/
 │   ├── registry.py      # name-based registry
 │   └── grafana.py       # planned Grafana backend (scaffolded)
 └── app/                 # Streamlit presentation layer
-    ├── main.py          # entry point (sidebar + tabs)
+    ├── main.py          # entry point (top dropdown row + tabs)
     ├── cli.py           # `f1-analysis` console script
     ├── widgets.py       # shared driver/lap selector
     └── views/           # one module per tab: telemetry, stats, results

--- a/src/f1_analysis/app/main.py
+++ b/src/f1_analysis/app/main.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import streamlit as st
 
+from f1_analysis.app.theme import inject_css, render_badge
 from f1_analysis.app.views import render_results, render_stats, render_telemetry
 from f1_analysis.config import get_settings
 from f1_analysis.data import list_event_locations, load_session
@@ -19,23 +20,38 @@ from f1_analysis.data import list_event_locations, load_session
 _SESSIONS = ("Practice 1", "Practice 2", "Practice 3", "Qualifying", "Race")
 
 
-def _sidebar() -> tuple[int, str, str]:
-    """Render the sidebar selectors and return (year, circuit, session)."""
+def _control_bar() -> tuple[int, str, str]:
+    """Render the status bar — its segments are live dropdowns.
+
+    Returns the selected (year, circuit, session).
+    """
     settings = get_settings()
-    with st.sidebar:
-        year = st.selectbox("Season", settings.available_years, index=0)
-        locations = list_event_locations(year)
-        circuit = st.selectbox("Circuit", locations)
-        session_name = st.selectbox("Session", _SESSIONS)
+    with st.container(key="pw-controls"):
+        season_col, circuit_col, session_col, _spacer, badge_col = st.columns(
+            [1.8, 2.2, 2.4, 3.0, 1.9], vertical_alignment="center"
+        )
+        with season_col:
+            year = st.selectbox("Season", settings.available_years, index=0)
+        with circuit_col:
+            circuit = st.selectbox("Circuit", list_event_locations(year))
+        with session_col:
+            session_name = st.selectbox("Session", _SESSIONS)
+        with badge_col:
+            render_badge("Data Loaded")
     return year, circuit, session_name
 
 
 def main() -> None:
     settings = get_settings()
-    st.set_page_config(page_title=f"{settings.app_title} (by matusso)", layout="wide")
+    st.set_page_config(
+        page_title=f"{settings.app_title} (by matusso)",
+        page_icon="🏁",
+        layout="wide",
+        initial_sidebar_state="collapsed",
+    )
+    inject_css()
 
-    year, circuit, session_name = _sidebar()
-    st.header(f"{year} — {circuit}")
+    year, circuit, session_name = _control_bar()
 
     telemetry_tab, stats_tab, results_tab = st.tabs(["Telemetry", "Stats", "Results"])
 

--- a/src/f1_analysis/app/theme.py
+++ b/src/f1_analysis/app/theme.py
@@ -1,0 +1,301 @@
+"""Pit-wall visual theme for the Streamlit app.
+
+Everything here is presentation-only: a global CSS injection, a status-bar
+header component, and helpers to render timing tables with Formula 1 broadcast
+heat colours. Colours are sourced from :mod:`f1_analysis.viz.style` so charts
+and tables stay visually consistent.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+import streamlit as st
+
+from f1_analysis.viz import style as S
+
+# ---------------------------------------------------------------------------
+# Global CSS
+# ---------------------------------------------------------------------------
+
+_CSS = f"""
+<style>
+@import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;700&display=swap');
+
+:root {{
+    --pw-bg: {S.BACKGROUND};
+    --pw-surface: {S.SURFACE};
+    --pw-surface-alt: {S.SURFACE_ALT};
+    --pw-border: {S.BORDER};
+    --pw-text: {S.TEXT};
+    --pw-muted: {S.MUTED};
+    --pw-accent: {S.ACCENT};
+    --pw-purple: {S.PURPLE};
+    --pw-green: {S.GREEN};
+    --pw-yellow: {S.YELLOW};
+    --pw-red: {S.RED};
+}}
+
+html, body, [class*="css"], .stApp, [data-testid="stAppViewContainer"] {{
+    font-family: {S.MONO_STACK};
+    background-color: var(--pw-bg);
+}}
+
+/* Tighten the layout so the board reads dense, like a real timing screen. */
+.block-container {{ padding-top: 1.4rem; padding-bottom: 2rem; max-width: 100%; }}
+[data-testid="stHeader"] {{ background: transparent; }}
+
+/* Headings: condensed, upper-case, cyan accent. */
+h1, h2, h3, h4 {{
+    font-family: {S.MONO_STACK};
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--pw-text);
+    font-weight: 700;
+}}
+h2, h3 {{
+    border-left: 3px solid var(--pw-accent);
+    padding-left: 0.55rem;
+    color: var(--pw-accent);
+    font-size: 1.0rem !important;
+}}
+
+/* Sidebar removed — controls live in the status bar. */
+[data-testid="stSidebar"],
+[data-testid="stSidebarCollapsedControl"],
+[data-testid="collapsedControl"] {{ display: none !important; }}
+
+/* In-tab dropdowns (driver pickers) */
+[data-testid="stSelectbox"] label {{
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    font-size: 0.68rem;
+    color: var(--pw-muted);
+}}
+[data-testid="stSelectbox"] div[data-baseweb="select"] > div {{
+    background-color: var(--pw-surface);
+    border: 1px solid var(--pw-border);
+    border-radius: 3px;
+    font-family: {S.MONO_STACK};
+    font-weight: 600;
+}}
+[data-testid="stSelectbox"] div[data-baseweb="select"] > div:focus-within {{
+    border-color: var(--pw-accent);
+}}
+
+/* ---- Status bar: segments are live dropdowns ---------------------------
+   The whole row is framed as one bar; each segment column carries a right
+   divider, a tiny upper-case label, and a large monospace value. */
+.st-key-pw-controls [data-testid="stHorizontalBlock"] {{
+    border: 1px solid var(--pw-border);
+    background: var(--pw-surface);
+    border-radius: 4px;
+    gap: 0;
+    margin-bottom: 1.1rem;
+    align-items: stretch;
+}}
+.st-key-pw-controls [data-testid="stColumn"]:nth-child(-n+3) {{
+    border-right: 1px solid var(--pw-border);
+}}
+.st-key-pw-controls [data-testid="stColumn"] {{ padding: 0.4rem 0.85rem; }}
+
+/* Tiny segment label */
+.st-key-pw-controls [data-testid="stSelectbox"] label {{
+    margin-bottom: 0.05rem;
+    font-size: 0.62rem;
+    letter-spacing: 0.12em;
+    color: var(--pw-muted);
+}}
+/* Turn the select into a borderless, large-value readout */
+.st-key-pw-controls [data-testid="stSelectbox"] div[data-baseweb="select"] > div {{
+    background: transparent;
+    border: none;
+    box-shadow: none;
+    padding-left: 0;
+    min-height: 2rem;
+}}
+.st-key-pw-controls [data-testid="stSelectbox"] div[data-baseweb="select"],
+.st-key-pw-controls [data-testid="stSelectbox"] div[data-baseweb="select"] * {{
+    font-family: {S.MONO_STACK};
+    font-weight: 700;
+    font-size: 1.1rem;
+    color: var(--pw-text) !important;
+}}
+/* Keep the value fully visible and shrink the chevron footprint. */
+.st-key-pw-controls [data-testid="stSelectbox"] div[data-baseweb="select"] > div:first-child {{
+    overflow: visible;
+}}
+.st-key-pw-controls [data-testid="stSelectbox"] svg {{
+    height: 0.95rem !important;
+    width: 0.95rem !important;
+}}
+/* First segment (Season) picks up the cyan accent, like the reference. */
+.st-key-pw-controls [data-testid="stColumn"]:first-child div[data-baseweb="select"],
+.st-key-pw-controls [data-testid="stColumn"]:first-child div[data-baseweb="select"] * {{
+    color: var(--pw-accent) !important;
+}}
+/* Badge sits flush right in its column */
+.st-key-pw-controls [data-testid="stColumn"]:last-child {{
+    display: flex; justify-content: flex-end; align-items: center;
+    border-right: none;
+}}
+.st-key-pw-controls .pw-badge {{ margin: 0; }}
+
+/* Tabs */
+[data-baseweb="tab-list"] {{ gap: 2px; border-bottom: 1px solid var(--pw-border); }}
+[data-baseweb="tab"] {{
+    background-color: var(--pw-surface);
+    border: 1px solid var(--pw-border);
+    border-bottom: none;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    font-size: 0.8rem;
+    padding: 0.35rem 1.1rem;
+}}
+[data-baseweb="tab"][aria-selected="true"] {{
+    color: var(--pw-bg);
+    background-color: var(--pw-accent);
+    font-weight: 700;
+}}
+
+/* Metrics -> compact instrument tiles */
+[data-testid="stMetric"] {{
+    background-color: var(--pw-surface);
+    border: 1px solid var(--pw-border);
+    border-radius: 3px;
+    padding: 0.5rem 0.7rem;
+}}
+[data-testid="stMetricLabel"] {{
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--pw-muted);
+    font-size: 0.7rem;
+}}
+[data-testid="stMetricValue"] {{
+    font-family: {S.MONO_STACK};
+    font-weight: 700;
+    font-size: 1.35rem;
+    color: var(--pw-text);
+}}
+
+/* ---- Status badge ------------------------------------------------------ */
+.pw-badge {{
+    display: inline-block; padding: 0.28rem 0.8rem;
+    border-radius: 3px; font-weight: 700; font-size: 0.75rem;
+    letter-spacing: 0.1em; text-transform: uppercase;
+    background: rgba(0,230,118,0.14); color: var(--pw-green);
+    border: 1px solid var(--pw-green);
+}}
+
+/* ---- Timing table ------------------------------------------------------ */
+.pw-timing {{ border-collapse: collapse; width: 100%; font-family: {S.MONO_STACK}; }}
+.pw-timing th {{
+    background: var(--pw-surface-alt); color: var(--pw-muted);
+    text-transform: uppercase; letter-spacing: 0.08em; font-size: 0.68rem;
+    text-align: right; padding: 0.4rem 0.6rem; border-bottom: 1px solid var(--pw-border);
+}}
+.pw-timing td {{
+    padding: 0.28rem 0.6rem; font-size: 0.82rem; text-align: right;
+    border-bottom: 1px solid #14181e; white-space: nowrap;
+}}
+.pw-timing td.txt {{ text-align: left; }}
+</style>
+"""
+
+
+def inject_css() -> None:
+    """Inject the global pit-wall stylesheet (call once, early)."""
+    st.markdown(_CSS, unsafe_allow_html=True)
+
+
+# ---------------------------------------------------------------------------
+# Status bar
+# ---------------------------------------------------------------------------
+
+
+def render_badge(text: str) -> None:
+    """Render the status badge shown at the right of the control bar."""
+    st.markdown(f'<div class="pw-badge">{text}</div>', unsafe_allow_html=True)
+
+
+# ---------------------------------------------------------------------------
+# Timing-table heat colouring
+# ---------------------------------------------------------------------------
+
+
+def _lerp_hex(a: str, b: str, t: float) -> str:
+    t = max(0.0, min(1.0, t))
+    ar, ag, ab = (int(a[i : i + 2], 16) for i in (1, 3, 5))
+    br, bg, bb = (int(b[i : i + 2], 16) for i in (1, 3, 5))
+    r = round(ar + (br - ar) * t)
+    g = round(ag + (bg - ag) * t)
+    bl = round(ab + (bb - ab) * t)
+    return f"#{r:02x}{g:02x}{bl:02x}"
+
+
+def _heat(t: float) -> str:
+    """Green (fast) -> yellow -> red (slow) for a normalised gap ``t``."""
+    if t <= 0.5:
+        return _lerp_hex(S.GREEN, S.YELLOW, t / 0.5)
+    return _lerp_hex(S.YELLOW, S.RED, (t - 0.5) / 0.5)
+
+
+def _cell_css(bg: str, dark_text: bool = True) -> str:
+    fg = "#0a0a0a" if dark_text else "#ffffff"
+    return f"background-color:{bg};color:{fg};font-weight:600;"
+
+
+def timing_table_html(
+    numeric: pd.DataFrame,
+    display: pd.DataFrame,
+    heat_columns: list[str],
+    team_colors: dict[int, str],
+    text_columns: list[str],
+) -> str:
+    """Build a heat-coloured timing table as standalone HTML.
+
+    Args:
+        numeric: numeric values (seconds) used only for colour scaling.
+        display: pre-formatted strings shown in each cell.
+        heat_columns: columns to colour green->red, min highlighted purple.
+        team_colors: row-index -> team colour (used to tint the first text col).
+        text_columns: left-aligned, non-numeric columns.
+    """
+    styles = pd.DataFrame("", index=display.index, columns=display.columns)
+
+    for col in heat_columns:
+        values = numeric[col]
+        finite = values.dropna()
+        if finite.empty:
+            continue
+        fastest = finite.min()
+        spread = finite.max() - fastest
+        for idx, value in values.items():
+            if pd.isna(value):
+                continue
+            if value == fastest:
+                styles.at[idx, col] = _cell_css(S.PURPLE, dark_text=False)
+            else:
+                t = 0.0 if spread == 0 else (value - fastest) / spread
+                styles.at[idx, col] = _cell_css(_heat(t), dark_text=True)
+
+    # Tint the leading text column (driver) with the team colour.
+    if text_columns:
+        driver_col = text_columns[0]
+        for idx in display.index:
+            color = team_colors.get(idx)
+            if color:
+                styles.at[idx, driver_col] = f"color:{color};font-weight:700;"
+
+    header = "".join(f"<th>{c}</th>" for c in display.columns)
+    rows = []
+    for idx in display.index:
+        cells = []
+        for col in display.columns:
+            css = styles.at[idx, col]
+            klass = ' class="txt"' if col in text_columns else ""
+            cells.append(f'<td{klass} style="{css}">{display.at[idx, col]}</td>')
+        rows.append(f"<tr>{''.join(cells)}</tr>")
+    return (
+        f'<table class="pw-timing"><thead><tr>{header}</tr></thead>'
+        f"<tbody>{''.join(rows)}</tbody></table>"
+    )

--- a/src/f1_analysis/app/views/results.py
+++ b/src/f1_analysis/app/views/results.py
@@ -1,4 +1,4 @@
-"""Results tab: qualifying classification and per-driver Q1/Q2/Q3 times."""
+"""Results tab: qualifying classification as a pit-wall timing board."""
 
 from __future__ import annotations
 
@@ -6,32 +6,50 @@ import pandas as pd
 import streamlit as st
 from fastf1.core import Session
 
-_QUALI_COLUMNS = ["Position", "FullName", "TeamName", "Q1", "Q2", "Q3"]
+from f1_analysis.app.theme import timing_table_html
+from f1_analysis.data.loader import normalise_hex
+
+_Q_COLUMNS = ("Q1", "Q2", "Q3")
 
 
-def _format_laptime(value: object) -> str:
-    """Render a lap time as ``M:SS.mmm``; blank when the driver has no time."""
-    delta = pd.to_timedelta(value)
-    if pd.isna(delta):
-        return ""
-    total = delta.total_seconds()
-    minutes, seconds = divmod(total, 60)
-    return f"{int(minutes)}:{seconds:06.3f}"
+def _format_laptime(seconds: float) -> str:
+    """Render seconds as ``M:SS.mmm``; blank when there is no time."""
+    if pd.isna(seconds):
+        return "—"
+    minutes, secs = divmod(float(seconds), 60)
+    return f"{int(minutes)}:{secs:06.3f}"
 
 
 def render_results(session: Session) -> None:
-    st.subheader("Qualifying results")
+    st.subheader("Qualifying — best sector & lap times")
 
     results = session.results.copy()
-    display = pd.DataFrame(
-        {
-            "Pos": results["Position"].astype("Int64"),
-            "Driver": results["FullName"],
-            "Team": results["TeamName"],
-            "Q1": results["Q1"].map(_format_laptime),
-            "Q2": results["Q2"].map(_format_laptime),
-            "Q3": results["Q3"].map(_format_laptime),
-        }
-    ).sort_values("Pos")
+    results = results.sort_values("Position")
 
-    st.table(display.set_index("Pos"))
+    # Numeric seconds (for heat scaling) keyed by position for a stable index.
+    numeric = pd.DataFrame(index=results.index)
+    for col in _Q_COLUMNS:
+        numeric[col] = pd.to_timedelta(results[col]).dt.total_seconds()
+
+    display = pd.DataFrame(index=results.index)
+    display["POS"] = results["Position"].astype("Int64").astype(str)
+    display["DRIVER"] = results["Abbreviation"]
+    display["TEAM"] = results["TeamName"]
+    for col in _Q_COLUMNS:
+        display[col] = numeric[col].map(_format_laptime)
+
+    # Align numeric frame to the display columns so styling lookups line up.
+    numeric = numeric.reindex(columns=list(display.columns), fill_value=float("nan"))
+
+    team_colors = {
+        idx: normalise_hex(color) for idx, color in results["TeamColor"].items()
+    }
+
+    html = timing_table_html(
+        numeric=numeric,
+        display=display,
+        heat_columns=list(_Q_COLUMNS),
+        team_colors=team_colors,
+        text_columns=["DRIVER", "TEAM"],
+    )
+    st.markdown(html, unsafe_allow_html=True)

--- a/src/f1_analysis/config.py
+++ b/src/f1_analysis/config.py
@@ -33,7 +33,7 @@ class Settings(BaseSettings):
         description="Directory FastF1 uses to cache downloaded session data.",
     )
     available_years: tuple[int, ...] = Field(
-        default=(2019, 2020, 2021, 2022, 2023, 2024, 2025),
+        default=(2019, 2020, 2021, 2022, 2023, 2024, 2025, 2026),
         description="Seasons offered in the year selector.",
     )
 

--- a/src/f1_analysis/data/loader.py
+++ b/src/f1_analysis/data/loader.py
@@ -57,7 +57,7 @@ def load_session(
     return session
 
 
-def _normalise_hex(color: str | None) -> str:
+def normalise_hex(color: str | None) -> str:
     """Return a ``#RRGGBB`` string; fall back to white for missing colours."""
     if not color:
         return "#FFFFFF"
@@ -74,7 +74,7 @@ def build_driver_index(session: Session) -> dict[str, DriverRef]:
             full_name=info["FullName"],
             abbreviation=info["Abbreviation"],
             team_name=info.get("TeamName", ""),
-            team_color=_normalise_hex(info.get("TeamColor")),
+            team_color=normalise_hex(info.get("TeamColor")),
         )
         index[ref.full_name] = ref
     return index

--- a/src/f1_analysis/viz/__init__.py
+++ b/src/f1_analysis/viz/__init__.py
@@ -1,5 +1,6 @@
 """Visualization layer: builds Plotly figures from FastF1 telemetry."""
 
+from f1_analysis.viz import style
 from f1_analysis.viz.telemetry import TELEMETRY_CHANNELS, TelemetryChannel, compare_channel
 
-__all__ = ["TELEMETRY_CHANNELS", "TelemetryChannel", "compare_channel"]
+__all__ = ["TELEMETRY_CHANNELS", "TelemetryChannel", "compare_channel", "style"]

--- a/src/f1_analysis/viz/style.py
+++ b/src/f1_analysis/viz/style.py
@@ -1,0 +1,72 @@
+"""Shared visual language for the pit-wall aesthetic.
+
+Central definition of the colour palette and the Plotly layout used across every
+chart, so figures and timing tables read as one system. Timing colours follow
+Formula 1 broadcast convention:
+
+* **purple**  — overall (session) fastest
+* **green**   — personal best / improvement
+* **yellow**  — a set but slower time (baseline)
+* **red**     — loss / in-pit / out lap
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# --- Core surfaces -----------------------------------------------------------
+BACKGROUND = "#0a0a0a"
+SURFACE = "#12151a"
+SURFACE_ALT = "#171b22"
+GRID = "#20262f"
+BORDER = "#2a313c"
+TEXT = "#e8e8e8"
+MUTED = "#8a93a2"
+
+# --- Timing semantics --------------------------------------------------------
+ACCENT = "#00e5ff"  # cyan — UI accent / current
+PURPLE = "#b13bff"  # overall fastest
+GREEN = "#00e676"  # personal best / gain
+YELLOW = "#ffd400"  # slower / baseline
+RED = "#ff2d55"  # loss / pit / out
+
+MONO_STACK = (
+    '"JetBrains Mono", "Roboto Mono", "SFMono-Regular", "Consolas", '
+    '"Menlo", ui-monospace, monospace'
+)
+
+
+def pitwall_layout(**overrides: Any) -> dict[str, Any]:
+    """Return a Plotly ``layout`` dict for the pit-wall look.
+
+    Pass keyword overrides (e.g. ``title="Speed"``) to merge on top.
+    """
+    layout: dict[str, Any] = {
+        "paper_bgcolor": BACKGROUND,
+        "plot_bgcolor": BACKGROUND,
+        "font": {"family": MONO_STACK, "color": TEXT, "size": 12},
+        "margin": {"l": 48, "r": 16, "t": 40, "b": 40},
+        "hovermode": "x unified",
+        "hoverlabel": {"font": {"family": MONO_STACK}, "bgcolor": SURFACE},
+        "legend": {
+            "orientation": "h",
+            "yanchor": "bottom",
+            "y": 1.02,
+            "x": 0,
+            "font": {"family": MONO_STACK, "size": 11},
+        },
+        "xaxis": {
+            "gridcolor": GRID,
+            "zerolinecolor": GRID,
+            "linecolor": BORDER,
+            "tickfont": {"family": MONO_STACK, "size": 10, "color": MUTED},
+        },
+        "yaxis": {
+            "gridcolor": GRID,
+            "zerolinecolor": GRID,
+            "linecolor": BORDER,
+            "tickfont": {"family": MONO_STACK, "size": 10, "color": MUTED},
+        },
+    }
+    layout.update(overrides)
+    return layout

--- a/src/f1_analysis/viz/telemetry.py
+++ b/src/f1_analysis/viz/telemetry.py
@@ -13,6 +13,7 @@ import plotly.graph_objects as go
 from fastf1.core import Lap
 
 from f1_analysis.data.models import DriverRef
+from f1_analysis.viz.style import pitwall_layout
 
 
 @dataclass(frozen=True, slots=True)
@@ -60,7 +61,7 @@ def compare_channel(
             x=tel_one["Distance"],
             y=tel_one[channel.key],
             name=driver_one.abbreviation,
-            line={"color": color_one},
+            line={"color": color_one, "width": 2},
             mode="lines",
         )
     )
@@ -69,16 +70,14 @@ def compare_channel(
             x=tel_two["Distance"],
             y=tel_two[channel.key],
             name=driver_two.abbreviation,
-            line={"color": color_two},
+            line={"color": color_two, "width": 2},
             mode="lines",
         )
     )
     figure.update_layout(
-        title=channel.title,
-        xaxis_title=_X_LABEL,
-        yaxis_title=channel.y_label,
-        margin={"l": 40, "r": 20, "t": 40, "b": 40},
-        legend={"orientation": "h", "yanchor": "bottom", "y": 1.02},
-        hovermode="x unified",
+        **pitwall_layout(
+            xaxis_title=_X_LABEL,
+            yaxis_title=channel.y_label,
+        )
     )
     return figure


### PR DESCRIPTION
- Update configuration to include the 2026 season  
- Apply a dark, pit-wall-inspired theme using custom colors and monospace font via Streamlit config and runtime CSS injection  
- Move year, circuit, and session selectors from the sidebar to a top status bar for faster access  
- Collapse the sidebar by default  
- Replace basic line charts with `pitwall_layout` in telemetry visualizations for consistent styling  
- Refactor the results view into a timing-board-style HTML table using `timing_table_html`