### PR TITLE
feat(app): add data availability checks and no-data UI

### DIFF
--- a/src/f1_analysis/app/main.py
+++ b/src/f1_analysis/app/main.py
@@ -10,15 +10,42 @@ Both require the package to be importable (``pip install -e .``).
 
 from __future__ import annotations
 
-import streamlit as st
+from collections.abc import Callable
 
-from f1_analysis.app.theme import inject_css, render_badge
+import streamlit as st
+from fastf1.core import Session
+from fastf1.exceptions import DataNotLoadedError
+
+from f1_analysis.app.theme import inject_css, render_badge, render_unavailable
 from f1_analysis.app.views import render_results, render_telemetry
 from f1_analysis.config import get_settings
 from f1_analysis.data import list_event_locations, load_session
 
 _SESSIONS = ("Practice 1", "Practice 2", "Practice 3", "Qualifying", "Race")
 _DASHBOARDS = ("Telemetry", "Results")
+
+
+def _is_empty(getter: Callable[[], object]) -> bool:
+    """True if a FastF1 data accessor is empty or was never loaded."""
+    try:
+        return bool(getter().empty)  # type: ignore[attr-defined]
+    except DataNotLoadedError:
+        return True
+
+
+@st.cache_resource(show_spinner="Loading session data…")
+def _cached_session(year: int, circuit: str, session_name: str, telemetry: bool) -> Session:
+    """Load a session once per (selection, telemetry) and reuse across reruns.
+
+    Caching avoids re-hitting the FastF1 data API on every widget interaction.
+    If the fetch produced no data at all (API unreachable, or a future session),
+    we raise instead of returning — Streamlit does not cache on exception, so the
+    next interaction retries rather than caching an empty session.
+    """
+    session = load_session(year, circuit, session_name, telemetry=telemetry, weather=False)
+    if _is_empty(lambda: session.laps) and _is_empty(lambda: session.results):
+        raise DataNotLoadedError(f"No data loaded for {circuit} {session_name}.")
+    return session
 
 
 def _control_bar() -> tuple[int, str, str, str]:
@@ -56,12 +83,21 @@ def main() -> None:
 
     year, circuit, session_name, dashboard = _control_bar()
 
-    # Only the selected dashboard's session is loaded.
-    session = load_session(year, circuit, session_name)
-    if dashboard == "Telemetry":
-        render_telemetry(session)
-    else:  # Results — classification for the chosen session
-        render_results(session)
+    # Only the selected dashboard's session is loaded (telemetry only when needed).
+    try:
+        session = _cached_session(
+            year, circuit, session_name, telemetry=(dashboard == "Telemetry")
+        )
+        if dashboard == "Telemetry":
+            render_telemetry(session)
+        else:  # Results — classification for the chosen session
+            render_results(session)
+    except DataNotLoadedError:
+        render_unavailable(
+            f"Timing data for <b>{circuit} · {session_name}</b> could not be loaded. "
+            "The session may not have taken place yet, or the F1 data provider is "
+            "temporarily unavailable — try another session or season."
+        )
 
 
 if __name__ == "__main__":

--- a/src/f1_analysis/app/theme.py
+++ b/src/f1_analysis/app/theme.py
@@ -231,6 +231,18 @@ h2, h3 {{
     color: var(--pw-purple); font-weight: 700; letter-spacing: 0.08em;
 }}
 
+/* ---- Unavailable / no-data notice -------------------------------------- */
+.pw-alert {{
+    border: 1px solid var(--pw-red); border-left-width: 4px;
+    background: rgba(255,45,85,0.08); color: var(--pw-text);
+    border-radius: 4px; padding: 0.9rem 1.1rem; font-size: 0.9rem;
+}}
+.pw-alert .hd {{
+    display: block; color: var(--pw-red); font-weight: 700;
+    text-transform: uppercase; letter-spacing: 0.1em; font-size: 0.72rem;
+    margin-bottom: 0.35rem;
+}}
+
 /* ---- Timing table ------------------------------------------------------ */
 .pw-timing {{ border-collapse: collapse; width: 100%; font-family: {S.MONO_STACK}; }}
 .pw-timing th {{
@@ -260,6 +272,14 @@ def inject_css() -> None:
 def render_badge(text: str) -> None:
     """Render the status badge shown at the right of the control bar."""
     st.markdown(f'<div class="pw-badge">{text}</div>', unsafe_allow_html=True)
+
+
+def render_unavailable(message: str) -> None:
+    """Render a styled 'data unavailable' notice in place of a dashboard."""
+    st.markdown(
+        f'<div class="pw-alert"><span class="hd">Data unavailable</span>{message}</div>',
+        unsafe_allow_html=True,
+    )
 
 
 def _format_laptime(seconds: float | None) -> str:

--- a/src/f1_analysis/app/views/results.py
+++ b/src/f1_analysis/app/views/results.py
@@ -13,7 +13,7 @@ import pandas as pd
 import streamlit as st
 from fastf1.core import Session
 
-from f1_analysis.app.theme import timing_table_html
+from f1_analysis.app.theme import render_unavailable, timing_table_html
 from f1_analysis.data.loader import normalise_hex
 
 _Q_COLUMNS = ("Q1", "Q2", "Q3")
@@ -84,6 +84,9 @@ def _emit(
 # --------------------------------------------------------------------------- #
 def _render_qualifying(session: Session) -> None:
     st.subheader(f"{session.name} — best sector & lap times")
+    if session.results.empty:
+        render_unavailable("No qualifying classification is available for this session.")
+        return
     results = session.results.copy().sort_values("Position").reset_index(drop=True)
 
     numeric = pd.DataFrame(index=results.index)
@@ -101,6 +104,9 @@ def _render_qualifying(session: Session) -> None:
 
 def _render_race(session: Session) -> None:
     st.subheader(f"{session.name} — classification")
+    if session.results.empty:
+        render_unavailable("No classification is available for this session yet.")
+        return
     results = session.results.copy().sort_values("Position").reset_index(drop=True)
 
     times = pd.to_timedelta(results["Time"]).dt.total_seconds()

--- a/src/f1_analysis/app/views/telemetry.py
+++ b/src/f1_analysis/app/views/telemetry.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import streamlit as st
 from fastf1.core import Session
 
-from f1_analysis.app.theme import render_lap_summary
+from f1_analysis.app.theme import render_lap_summary, render_unavailable
 from f1_analysis.app.widgets import driver_lap_selector
 from f1_analysis.data import build_driver_index
 from f1_analysis.data.loader import lap_sectors, lap_summary
@@ -29,6 +29,9 @@ def _render_sectors(sectors: LapSectors, reference: LapSectors | None = None) ->
 
 def render_telemetry(session: Session) -> None:
     laps = session.laps
+    if laps.empty:
+        render_unavailable("No lap data is available for this session.")
+        return
     driver_index: dict[str, DriverRef] = build_driver_index(session)
 
     left, right = st.columns(2)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,25 @@
+"""Tests for app-level guards."""
+
+from fastf1.exceptions import DataNotLoadedError
+
+from f1_analysis.app.main import _is_empty
+
+
+class _Frame:
+    def __init__(self, empty: bool) -> None:
+        self.empty = empty
+
+
+def test_is_empty_true_for_empty_frame():
+    assert _is_empty(lambda: _Frame(empty=True)) is True
+
+
+def test_is_empty_false_for_populated_frame():
+    assert _is_empty(lambda: _Frame(empty=False)) is False
+
+
+def test_is_empty_true_when_data_not_loaded():
+    def boom() -> object:
+        raise DataNotLoadedError("not loaded")
+
+    assert _is_empty(boom) is True


### PR DESCRIPTION
- Add `_is_empty` helper to detect empty or unloaded FastF1 data  
- Render styled "Data unavailable" notices when session results or laps are missing  
- Protect qualifying and race views with empty checks before rendering tables